### PR TITLE
Exceptions

### DIFF
--- a/src/main/java/cardibuddy/commons/core/Messages.java
+++ b/src/main/java/cardibuddy/commons/core/Messages.java
@@ -9,7 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_DECK = "A deck should not have a question and/or an answer.";
     public static final String MESSAGE_INVALID_DECK_DISPLAYED_INDEX = "The deck index provided is invalid";
-    public static final String MESSAGE_INVALID_FLASHCARD = "A deck should not have a question and/or an answer.";
+    public static final String MESSAGE_INVALID_FLASHCARD = "A flashcard should have a question and an answer.";
     public static final String MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX = "The card index provided is invalid";
     public static final String MESSAGE_DECKS_LISTED_OVERVIEW = "%1$d decks listed!";
     public static final String MESSAGE_FLASHCARDS_LISTED_OVERVIEW = "%1$d cards listed!";

--- a/src/main/java/cardibuddy/commons/core/Messages.java
+++ b/src/main/java/cardibuddy/commons/core/Messages.java
@@ -7,6 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_DECK = "A deck should not have a question and/or an answer.";
     public static final String MESSAGE_INVALID_DECK_DISPLAYED_INDEX = "The deck index provided is invalid";
     public static final String MESSAGE_INVALID_CARD_DISPLAYED_INDEX = "The card index provided is invalid";
     public static final String MESSAGE_DECKS_LISTED_OVERVIEW = "%1$d decks listed!";

--- a/src/main/java/cardibuddy/commons/core/Messages.java
+++ b/src/main/java/cardibuddy/commons/core/Messages.java
@@ -9,9 +9,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_DECK = "A deck should not have a question and/or an answer.";
     public static final String MESSAGE_INVALID_DECK_DISPLAYED_INDEX = "The deck index provided is invalid";
-    public static final String MESSAGE_INVALID_CARD_DISPLAYED_INDEX = "The card index provided is invalid";
+    public static final String MESSAGE_INVALID_FLASHCARD = "A deck should not have a question and/or an answer.";
+    public static final String MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX = "The card index provided is invalid";
     public static final String MESSAGE_DECKS_LISTED_OVERVIEW = "%1$d decks listed!";
-    public static final String MESSAGE_CARDS_LISTED_OVERVIEW = "%1$d cards listed!";
-    public static final String MESSAGE_DECK_CANNOT_BE_CARD = "Operation would result in the object created "
+    public static final String MESSAGE_FLASHCARDS_LISTED_OVERVIEW = "%1$d cards listed!";
+    public static final String MESSAGE_DECK_CANNOT_BE_FLASHCARD = "Operation would result in the object created "
             + "being both a deck and a card!";
 }

--- a/src/main/java/cardibuddy/logic/commands/AddCommand.java
+++ b/src/main/java/cardibuddy/logic/commands/AddCommand.java
@@ -22,18 +22,47 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a deck/flashcard to the cardibuddy book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a deck/flashcard to the cardibuddy book. \n"
             + "Parameters: "
-            + "[ " + PREFIX_DECK + "DECK_TITLE] "
-            + "[ " + PREFIX_FLASHCARD + "CARD_TITLE] "
+            + PREFIX_DECK + "DECK_TITLE "
             // + PREFIX_TITLE + "Title \n"
             + "[" + PREFIX_TAG + "TAG]... "
-            + "[" + PREFIX_QUESTION + "QUESTION] "
-            + "[" + PREFIX_ANSWER + "ANSWER]\n"
+            + "|| "
+            + PREFIX_FLASHCARD + " "
+            + PREFIX_QUESTION + "QUESTION "
+            + PREFIX_ANSWER + "ANSWER "
+            + "[" + PREFIX_TAG + "TAG]... \n"
+            + "Example (adding a deck): " + COMMAND_WORD + " "
+            + PREFIX_DECK + "cs2103t "
+            + PREFIX_TAG + "Hard "
+            + PREFIX_TAG + "Software Engineering \n"
+            + "Example (adding a flashcard): " + COMMAND_WORD + " "
+            + PREFIX_FLASHCARD + " "
+            + PREFIX_QUESTION + "A queue cannot be implemented using an array "
+            + PREFIX_ANSWER + "False "
+            + PREFIX_TAG + "Programming";
+
+    public static final String MESSAGE_ADD_DECK = "To add a deck to the cardibuddy book. \n"
+            + "Parameters: "
+            + PREFIX_DECK + "DECK_TITLE "
+            // + PREFIX_TITLE + "Title \n"
+            + "[" + PREFIX_TAG + "TAG]... \n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DECK + "cs2103t "
             + PREFIX_TAG + "Hard "
             + PREFIX_TAG + "Software Engineering";
+
+    public static final String MESSAGE_ADD_FLASHCARD = "To add a flashcard to the cardibuddy book. \n"
+            + "Parameters: "
+            + PREFIX_FLASHCARD + "CARD_TITLE "
+            + PREFIX_QUESTION + "QUESTION "
+            + PREFIX_ANSWER + "ANSWER"
+            + "[" + PREFIX_TAG + "TAG]... \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_FLASHCARD + " "
+            + PREFIX_QUESTION + "A queue cannot be implemented using an array "
+            + PREFIX_ANSWER + "False "
+            + PREFIX_TAG + "Programming";
 
     public static final String MESSAGE_SUCCESS = "New object added: %1$s";
     public static final String MESSAGE_DUPLICATE_DECK = "This deck already exists in the cardibuddy library";

--- a/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
+++ b/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
@@ -49,15 +49,18 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_FLASHCARD)) {
             // both PREFIX_DECK and PREFIX_FLASHCARD are present
-            throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_FLASHCARD, AddCommand.MESSAGE_USAGE));
+            throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_FLASHCARD
+                    + "\n" +  AddCommand.MESSAGE_USAGE));
         } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER) |
                 arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION) |
                 arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_ANSWER)) {
             //trying to add a deck with a question and/or an answer
-            throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK, AddCommand.MESSAGE_USAGE));
+            throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK + "\n"
+                    +  AddCommand.MESSAGE_ADD_DECK));
         } else if (arePrefixesPresent(argMultimap, PREFIX_FLASHCARD)) {
             if (!arePrefixesPresent(argMultimap, PREFIX_FLASHCARD, PREFIX_QUESTION, PREFIX_ANSWER)) {
-                throw new InvalidFlashcardException(String.format(MESSAGE_INVALID_FLASHCARD, AddCommand.MESSAGE_USAGE));
+                throw new InvalidFlashcardException(String.format(MESSAGE_INVALID_FLASHCARD + "\n"
+                        + AddCommand.MESSAGE_ADD_FLASHCARD));
             }
         }
         if (argMultimap.containsKey(PREFIX_DECK)) {

--- a/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
+++ b/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
@@ -2,6 +2,7 @@ package cardibuddy.logic.parser;
 
 import static cardibuddy.commons.core.Messages.MESSAGE_DECK_CANNOT_BE_CARD;
 import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_DECK;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_DECK;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_FLASHCARD;
@@ -18,6 +19,7 @@ import cardibuddy.logic.parser.exceptions.ParseException;
 import cardibuddy.model.deck.Deck;
 import cardibuddy.model.deck.Title;
 import cardibuddy.model.deck.exceptions.DeckCannotBeCardException;
+import cardibuddy.model.deck.exceptions.InvalidDeckException;
 import cardibuddy.model.flashcard.Answer;
 import cardibuddy.model.flashcard.Flashcard;
 import cardibuddy.model.flashcard.Question;
@@ -49,6 +51,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_FLASHCARD)) {
             // both PREFIX_DECK and PREFIX_FLASHCARD are present
             throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_CARD, AddCommand.MESSAGE_USAGE));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER)) {
+            //trying to add a deck with a question and/or an answer
+            throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK, AddCommand.MESSAGE_USAGE));
         }
 
         if (argMultimap.containsKey(PREFIX_DECK)) {

--- a/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
+++ b/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
@@ -1,6 +1,9 @@
 package cardibuddy.logic.parser;
 
-import static cardibuddy.commons.core.Messages.*;
+import static cardibuddy.commons.core.Messages.MESSAGE_DECK_CANNOT_BE_FLASHCARD;
+import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_DECK;
+import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_FLASHCARD;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_DECK;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_FLASHCARD;
@@ -51,9 +54,9 @@ public class AddCommandParser implements Parser<AddCommand> {
             // both PREFIX_DECK and PREFIX_FLASHCARD are present
             throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_FLASHCARD
                     + "\n" +  AddCommand.MESSAGE_USAGE));
-        } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER) |
-                arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION) |
-                arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_ANSWER)) {
+        } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER)
+                | arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION)
+                | arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_ANSWER)) {
             //trying to add a deck with a question and/or an answer
             throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK + "\n"
                     +  AddCommand.MESSAGE_ADD_DECK));

--- a/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
+++ b/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
@@ -53,13 +53,13 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_FLASHCARD)) {
             // both PREFIX_DECK and PREFIX_FLASHCARD are present
             throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_FLASHCARD
-                    + "\n" +  AddCommand.MESSAGE_USAGE));
+                    + "\n" + AddCommand.MESSAGE_USAGE));
         } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER)
                 | arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION)
                 | arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_ANSWER)) {
             //trying to add a deck with a question and/or an answer
             throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK + "\n"
-                    +  AddCommand.MESSAGE_ADD_DECK));
+                    + AddCommand.MESSAGE_ADD_DECK));
         } else if (arePrefixesPresent(argMultimap, PREFIX_FLASHCARD)) {
             if (!arePrefixesPresent(argMultimap, PREFIX_FLASHCARD, PREFIX_QUESTION, PREFIX_ANSWER)) {
                 throw new InvalidFlashcardException(String.format(MESSAGE_INVALID_FLASHCARD + "\n"

--- a/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
+++ b/src/main/java/cardibuddy/logic/parser/AddCommandParser.java
@@ -1,8 +1,6 @@
 package cardibuddy.logic.parser;
 
-import static cardibuddy.commons.core.Messages.MESSAGE_DECK_CANNOT_BE_CARD;
-import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static cardibuddy.commons.core.Messages.MESSAGE_INVALID_DECK;
+import static cardibuddy.commons.core.Messages.*;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_DECK;
 import static cardibuddy.logic.parser.CliSyntax.PREFIX_FLASHCARD;
@@ -23,6 +21,7 @@ import cardibuddy.model.deck.exceptions.InvalidDeckException;
 import cardibuddy.model.flashcard.Answer;
 import cardibuddy.model.flashcard.Flashcard;
 import cardibuddy.model.flashcard.Question;
+import cardibuddy.model.flashcard.exceptions.InvalidFlashcardException;
 import cardibuddy.model.tag.Tag;
 
 /**
@@ -50,12 +49,17 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_FLASHCARD)) {
             // both PREFIX_DECK and PREFIX_FLASHCARD are present
-            throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_CARD, AddCommand.MESSAGE_USAGE));
-        } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER)) {
+            throw new DeckCannotBeCardException(String.format(MESSAGE_DECK_CANNOT_BE_FLASHCARD, AddCommand.MESSAGE_USAGE));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION, PREFIX_ANSWER) |
+                arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_QUESTION) |
+                arePrefixesPresent(argMultimap, PREFIX_DECK, PREFIX_ANSWER)) {
             //trying to add a deck with a question and/or an answer
             throw new InvalidDeckException(String.format(MESSAGE_INVALID_DECK, AddCommand.MESSAGE_USAGE));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_FLASHCARD)) {
+            if (!arePrefixesPresent(argMultimap, PREFIX_FLASHCARD, PREFIX_QUESTION, PREFIX_ANSWER)) {
+                throw new InvalidFlashcardException(String.format(MESSAGE_INVALID_FLASHCARD, AddCommand.MESSAGE_USAGE));
+            }
         }
-
         if (argMultimap.containsKey(PREFIX_DECK)) {
             Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_DECK).get());
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/main/java/cardibuddy/model/deck/exceptions/DeckCannotBeCardException.java
+++ b/src/main/java/cardibuddy/model/deck/exceptions/DeckCannotBeCardException.java
@@ -8,8 +8,4 @@ public class DeckCannotBeCardException extends RuntimeException {
     public DeckCannotBeCardException(String message) {
         super(message);
     }
-
-    public DeckCannotBeCardException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/cardibuddy/model/deck/exceptions/DeckCannotBeCardException.java
+++ b/src/main/java/cardibuddy/model/deck/exceptions/DeckCannotBeCardException.java
@@ -8,4 +8,8 @@ public class DeckCannotBeCardException extends RuntimeException {
     public DeckCannotBeCardException(String message) {
         super(message);
     }
+
+    public DeckCannotBeCardException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/cardibuddy/model/deck/exceptions/InvalidDeckException.java
+++ b/src/main/java/cardibuddy/model/deck/exceptions/InvalidDeckException.java
@@ -1,0 +1,12 @@
+package cardibuddy.model.deck.exceptions;
+
+/**
+ * Signals that the operation will result in the creation of a deck with a question and/or an answer.
+ */
+public class InvalidDeckException extends RuntimeException {
+    public InvalidDeckException(String message) {
+        super(message);
+    }
+}
+
+

--- a/src/main/java/cardibuddy/model/deck/exceptions/InvalidDeckException.java
+++ b/src/main/java/cardibuddy/model/deck/exceptions/InvalidDeckException.java
@@ -10,3 +10,4 @@ public class InvalidDeckException extends RuntimeException {
 }
 
 
+

--- a/src/main/java/cardibuddy/model/flashcard/exceptions/InvalidFlashcardException.java
+++ b/src/main/java/cardibuddy/model/flashcard/exceptions/InvalidFlashcardException.java
@@ -1,0 +1,10 @@
+package cardibuddy.model.flashcard.exceptions;
+
+/**
+ * Signals that the operation will result in the creation of a flashcard with missing/wrong fields.
+ */
+public class InvalidFlashcardException extends RuntimeException {
+    public InvalidFlashcardException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/cardibuddy/storage/JsonAdaptedDeck.java
+++ b/src/main/java/cardibuddy/storage/JsonAdaptedDeck.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import cardibuddy.model.deck.Title;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/cardibuddy/storage/JsonAdaptedDeck.java
+++ b/src/main/java/cardibuddy/storage/JsonAdaptedDeck.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import cardibuddy.model.deck.Title;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -72,9 +73,9 @@ public class JsonAdaptedDeck extends JsonAdaptedView {
         }
 
         // TODO: add if conditions here to check formatting
-
+        Title modelTitle = new Title(title);
         final Set<Tag> modelTags = new HashSet<>(deckTags);
-        return new Deck(null, null); // TODO: to replace params with actual values
+        return new Deck(modelTitle, modelTags); // TODO: to replace params with actual values
     }
 
 }

--- a/src/main/java/cardibuddy/storage/JsonAdaptedFlashcard.java
+++ b/src/main/java/cardibuddy/storage/JsonAdaptedFlashcard.java
@@ -66,9 +66,9 @@ class JsonAdaptedFlashcard extends JsonAdaptedView {
         }
 
         final Set<Tag> modelTags = new HashSet<>(flashcardTags);
-        Deck testDeck = new Deck();
-        Question testQuestion = new Question(question);
-        ShortAnswer testAnswer = new ShortAnswer(answer);
-        return new Flashcard(testDeck, testQuestion, testAnswer);
+        Deck modelDeck = new Deck();
+        Question modelQuestion = new Question(question);
+        ShortAnswer modelAnswer = new ShortAnswer(answer);
+        return new Flashcard(modelDeck, modelQuestion, modelAnswer);
     }
 }

--- a/src/main/java/cardibuddy/storage/JsonSerializableCardiBuddy.java
+++ b/src/main/java/cardibuddy/storage/JsonSerializableCardiBuddy.java
@@ -11,8 +11,9 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import cardibuddy.commons.exceptions.IllegalValueException;
 import cardibuddy.model.CardiBuddy;
 import cardibuddy.model.ReadOnlyCardiBuddy;
-// import cardibuddy.model.deck.Deck;
-import cardibuddy.model.flashcard.Flashcard;
+import cardibuddy.model.deck.Deck;
+
+import static cardibuddy.logic.commands.AddCommand.MESSAGE_DUPLICATE_DECK;
 
 /**
  * An Immutable CardiBuddy that is serializable to JSON format.
@@ -20,22 +21,17 @@ import cardibuddy.model.flashcard.Flashcard;
 @JsonRootName(value = "cardibuddy")
 class JsonSerializableCardiBuddy {
 
-    //public static final String MESSAGE_DUPLICATE_DECK = "Decks list contains duplicate deck(s).";
-    public static final String MESSAGE_DUPLICATE_FLASHCARDS = "Flashcards list contains duplicate flashcard(s).";
+    public static final String MESSAGE_DUPLICATE_DECK = "Decks list contains duplicate deck(s).";
 
-    //private final List<JsonAdaptedDeck> decks = new ArrayList<>();
+    private final List<JsonAdaptedDeck> decks = new ArrayList<>();
     private final List<JsonAdaptedFlashcard> flashcards = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableCardiBuddy} with the given flashcards.
      */
-    // @JsonCreator
-    // public JsonSerializableCardiBuddy(@JsonProperty("decks") List<JsonAdaptedDeck> decks) {
-    // this.decks.addAll(decks);
-    //}
     @JsonCreator
-    public JsonSerializableCardiBuddy(@JsonProperty("flashcards") List<JsonAdaptedFlashcard> flashcards) {
-        this.flashcards.addAll(flashcards);
+    public JsonSerializableCardiBuddy(@JsonProperty("decks") List<JsonAdaptedDeck> decks) {
+        this.decks.addAll(decks);
     }
 
     /**
@@ -44,12 +40,8 @@ class JsonSerializableCardiBuddy {
      * @param source future changes to this will not affect the created {@code JsonSerializableCardiBuddy}.
      */
 
-    // public JsonSerializableCardiBuddy(ReadOnlyCardiBuddy source) {
-    //decks.addAll(source.getDeckList().stream().map(JsonAdaptedDeck::new).collect(Collectors.toList()));
-    // }
     public JsonSerializableCardiBuddy(ReadOnlyCardiBuddy source) {
-        flashcards.addAll(source.getFlashcardList().stream()
-                .map(JsonAdaptedFlashcard::new).collect(Collectors.toList()));
+        decks.addAll(source.getDeckList().stream().map(JsonAdaptedDeck::new).collect(Collectors.toList()));
     }
 
     /**
@@ -57,28 +49,17 @@ class JsonSerializableCardiBuddy {
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
-    // public CardiBuddy toModelType() throws IllegalValueException {
-    // CardiBuddy cardibuddy = new CardiBuddy();
-    // for (JsonAdaptedDeck jsonAdaptedDeck : decks) {
-    // Deck deck = jsonAdaptedDeck.toModelType();
-    // if (cardibuddy.hasDeck(deck)) {
-    // throw new IllegalValueException(MESSAGE_DUPLICATE_DECK);
-    // }
-    // cardibuddy.addDeck(deck);
-    // }
-    // return cardibuddy;
-    // }
-
     public CardiBuddy toModelType() throws IllegalValueException {
         CardiBuddy cardibuddy = new CardiBuddy();
-        for (JsonAdaptedFlashcard jsonAdaptedFlashcard : flashcards) {
-            Flashcard flashcard = jsonAdaptedFlashcard.toModelType();
-            if (cardibuddy.hasFlashcard(flashcard)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_FLASHCARDS);
+        for (JsonAdaptedDeck jsonAdaptedDeck : decks) {
+            Deck deck = jsonAdaptedDeck.toModelType();
+
+            if (cardibuddy.hasDeck(deck)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_DECK);
             }
-            cardibuddy.addFlashcard(flashcard);
+
+            cardibuddy.addDeck(deck);
         }
         return cardibuddy;
     }
-
 }

--- a/src/main/java/cardibuddy/storage/JsonSerializableCardiBuddy.java
+++ b/src/main/java/cardibuddy/storage/JsonSerializableCardiBuddy.java
@@ -12,9 +12,6 @@ import cardibuddy.commons.exceptions.IllegalValueException;
 import cardibuddy.model.CardiBuddy;
 import cardibuddy.model.ReadOnlyCardiBuddy;
 import cardibuddy.model.deck.Deck;
-
-import static cardibuddy.logic.commands.AddCommand.MESSAGE_DUPLICATE_DECK;
-
 /**
  * An Immutable CardiBuddy that is serializable to JSON format.
  */

--- a/src/main/java/cardibuddy/ui/MainWindow.java
+++ b/src/main/java/cardibuddy/ui/MainWindow.java
@@ -9,6 +9,8 @@ import cardibuddy.logic.commands.CommandResult;
 import cardibuddy.logic.commands.exceptions.CommandException;
 import cardibuddy.logic.parser.exceptions.ParseException;
 import cardibuddy.model.deck.exceptions.DeckCannotBeCardException;
+import cardibuddy.model.deck.exceptions.InvalidDeckException;
+import cardibuddy.model.flashcard.exceptions.InvalidFlashcardException;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -198,7 +200,8 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
-        } catch (CommandException | ParseException | DeckCannotBeCardException e) {
+        } catch (CommandException | ParseException | DeckCannotBeCardException | InvalidDeckException
+                | InvalidFlashcardException e) {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;


### PR DESCRIPTION
Added exceptions to AddCommandParser. Replaced the flashcard methods in JSON Serializable class back with the deck ones. 

Users should not be able to: 
- add a deck that has a question and/or answer 
- add a flashcard without a question and answer 
- add an object with deck and flashcard fields at the same time 

Possible other exceptions to be added: 
- add (throw exception for empty add command) 
- add q/question (throw invalid command exception)
- add a/answer (throw invalid command exception)